### PR TITLE
Fix case in filenames

### DIFF
--- a/Generals/Code/GameEngine/CMakeLists.txt
+++ b/Generals/Code/GameEngine/CMakeLists.txt
@@ -1049,7 +1049,7 @@ set(GAMEENGINE_SRC
     Include/GameNetwork/NetPacket.h
     Include/GameNetwork/NetworkDefs.h
     Include/GameNetwork/NetworkInterface.h
-    Include/GameNetwork/NetworkUtil.h
+    Include/GameNetwork/networkutil.h
     Include/GameNetwork/RankPointValue.h
     Include/GameNetwork/Transport.h
     Include/GameNetwork/udp.h

--- a/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -1,14 +1,14 @@
 # Set source files
 set(WWDOWNLOAD_SRC
     Download.cpp
-    Ftp.cpp
+    FTP.CPP
     registry.cpp
     urlBuilder.cpp
     Download.h
     DownloadDebug.h
-    DownloadDefs.h
-    Ftp.h
-    FtpDefs.h
+    downloaddefs.h
+    ftp.h
+    ftpdefs.h
     Registry.h
     urlBuilder.h
 )


### PR DESCRIPTION
Hey,

I just tried out to configure your branch on Linux and I got some errors because some cmake files did not match the actual source filenames. Windows does not care about letter cases, but Linux does, and it was easy enough to fix. Hope this helps. Maybe some day we get this running on Linux too. :)