### PR TITLE
Refactor loop initializations and improve const correctness in debug classes

### DIFF
--- a/GeneralsMD/Code/Libraries/Source/debug/debug_cmd.cpp
+++ b/GeneralsMD/Code/Libraries/Source/debug/debug_cmd.cpp
@@ -227,7 +227,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
       // regular I/O command
 
       // find I/O class
-			Debug::IOFactoryListEntry *cur=dbg.firstIOFactory;
+      Debug::IOFactoryListEntry *cur=dbg.firstIOFactory;
       for (;cur;cur=cur->next)
         if (!strcmp(argv[0],cur->ioID))
           break;

--- a/GeneralsMD/Code/Libraries/Source/debug/debug_debug.cpp
+++ b/GeneralsMD/Code/Libraries/Source/debug/debug_debug.cpp
@@ -880,7 +880,7 @@ Debug& Debug::operator<<(const MemDump &dump)
 
     // items
     const unsigned char *curByte=cur;
-		unsigned k=0;
+    unsigned k=0;
     for (;k<itemPerLine;k++,curByte+=dump.m_bytePerItem)
     {
       operator<<(" ");
@@ -974,7 +974,7 @@ void Debug::AddHResultTranslator(unsigned prio, HResultTranslator func, void *us
 
   // now find the right place to insert the translator
   // (slow but this function is not time critical)
-	unsigned k=0;
+  unsigned k=0;
   for (;k<Instance.numHrTranslators;++k)
     if (Instance.hrTranslators[k].prio<prio)
       break;
@@ -1224,7 +1224,7 @@ const char *Debug::AddLogGroup(const char *fileOrGroup, const char *descr)
   }
 
   // is that log group known?
-	KnownLogGroupList *cur=firstLogGroup;
+  KnownLogGroupList *cur=firstLogGroup;
   for (;cur;cur=cur->next)
   {
     if (!strcmp(cur->nameGroup,fileOrGroup))

--- a/GeneralsMD/Code/Libraries/Source/debug/debug_except.cpp
+++ b/GeneralsMD/Code/Libraries/Source/debug/debug_except.cpp
@@ -159,7 +159,7 @@ void DebugExceptionhandler::LogFPURegisters(Debug &dbg, struct _EXCEPTION_POINTE
       << "DataOfs:     " << Debug::Width(8) << flt.DataOffset
       << " DataSel: "    << Debug::Width(8) << flt.DataSelector << "\n";
 #if !defined(WOW64_SIZE_OF_80387_REGISTERS)
-	dbg << "Cr0NpxState: " << Debug::Width(8) << flt.Cr0NpxState << "\n";
+  dbg << "Cr0NpxState: " << Debug::Width(8) << flt.Cr0NpxState << "\n";
 #endif
 
   for (unsigned k=0;k<SIZE_OF_80387_REGISTERS/10;++k)
@@ -254,7 +254,7 @@ static BOOL CALLBACK ExceptionDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
   {
     LVCOLUMN c;
     c.mask=LVCF_TEXT|LVCF_WIDTH;
-		char ch[] = "";
+    char ch[] = "";
     c.pszText=ch;
     c.cx=690;
     ListView_InsertColumn(list,0,&c);
@@ -263,7 +263,7 @@ static BOOL CALLBACK ExceptionDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
     item.iItem=0;
     item.iSubItem=0;
     item.mask=LVIF_TEXT;
-		char pszTextStr[] = "No stack data available - check for dbghelp.dll";
+    char pszTextStr[] = "No stack data available - check for dbghelp.dll";
     item.pszText=pszTextStr;
 
     item.iItem=ListView_InsertItem(list,&item);
@@ -273,35 +273,35 @@ static BOOL CALLBACK ExceptionDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
     // add columns first
     LVCOLUMN c;
     c.mask=LVCF_TEXT|LVCF_WIDTH;
-		char ch[] = "";
+    char ch[] = "";
     c.pszText=ch;
     c.cx=0; // first column is empty (can't right-align 1st column)
     ListView_InsertColumn(list,0,&c);
 
     c.mask=LVCF_TEXT|LVCF_WIDTH|LVCF_FMT;
-		char pszTextAddress[] ="Address";
+    char pszTextAddress[] ="Address";
     c.pszText=pszTextAddress;
     c.cx=60;
     c.fmt=LVCFMT_RIGHT;
     ListView_InsertColumn(list,1,&c);
 
     c.mask=LVCF_TEXT|LVCF_WIDTH;
-		char pszTextModule[] ="Module";
+    char pszTextModule[] ="Module";
     c.pszText=pszTextModule;
     c.cx=120;
     ListView_InsertColumn(list,2,&c);
 
-		char pszTextSymbol[] ="Symbol";
+    char pszTextSymbol[] ="Symbol";
     c.pszText=pszTextSymbol;
     c.cx=300;
     ListView_InsertColumn(list,3,&c);
 
-		char pszTextFile[] ="File";
+    char pszTextFile[] ="File";
     c.pszText=pszTextFile;
     c.cx=130;
     ListView_InsertColumn(list,4,&c);
 
-		char pszTextLine[] ="Line";
+    char pszTextLine[] ="Line";
 		c.pszText=pszTextLine;
     c.cx=80;
     ListView_InsertColumn(list,5,&c);

--- a/GeneralsMD/Code/Libraries/Source/debug/debug_io_flat.cpp
+++ b/GeneralsMD/Code/Libraries/Source/debug/debug_io_flat.cpp
@@ -306,7 +306,7 @@ DebugIOFlat::~DebugIOFlat()
 
 void DebugIOFlat::Write(StringType type, const char *src, const char *str)
 {
-	SplitListEntry *cur=m_firstSplit;
+  SplitListEntry *cur=m_firstSplit;
   for (;cur;cur=cur->next)
   {
     if (!(cur->stringTypes&(1<<type)))
@@ -469,7 +469,7 @@ void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
       // create our filename, search for stream with same filename
       char fn[256];
       ExpandMagic(m_baseFilename,cur->name,fn);
-			StreamListEntry *stream=m_firstStream;
+      StreamListEntry *stream=m_firstStream;
       for (;stream;stream=stream->next)
         if (!strcmp(stream->stream->GetFilename(),fn))
           break;

--- a/GeneralsMD/Code/Libraries/Source/debug/debug_stack.cpp
+++ b/GeneralsMD/Code/Libraries/Source/debug/debug_stack.cpp
@@ -86,7 +86,7 @@ static void InitDbghelp(void)
 
   // Get function addresses
   unsigned *funcptr=gDbg.funcPtr;
-	unsigned k=0;
+  unsigned k=0;
   for (;DebughelpFunctionNames[k];++k,++funcptr)
   {
     *funcptr=(unsigned)GetProcAddress(g_dbghelp,DebughelpFunctionNames[k]);


### PR DESCRIPTION
Additional fixes found after merging https://github.com/TheSuperHackers/GeneralsGameCode/pull/452 and fixing the LINK of `profiledebug.lib`.

Not sure about operators.

~~(I was unable to prevent the indentation differences, even though I set my tabs to two spaces. sorry)~~