### PR TITLE
fix(vc6): Use unsigned __int64 and %I64X to support VC6 compiler in BitFlags.h

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/BitFlags.h
+++ b/Generals/Code/GameEngine/Include/Common/BitFlags.h
@@ -309,19 +309,19 @@ public:
 
 		for (int chunk = numChunks - 1; chunk >= 0; --chunk)
 		{
-			unsigned long long val = 0;
+			unsigned __int64 val = 0;
 			for (int bit = 0; bit < 64 && (chunk * 64 + bit) < NUMBITS; ++bit)
 			{
 				if (m_bits.test(chunk * 64 + bit))
-					val |= (unsigned long long)(1) << bit;
+					val |= (unsigned __int64)(1) << bit;
 			}
 
 			if (val != 0 || chunk == 0 || printedAny)
 			{
 				if (printedAny)
-					snprintf(chunkBuf, sizeof(chunkBuf), "%016llX", val);
+					snprintf(chunkBuf, sizeof(chunkBuf), "%016I64X", val);
 				else
-					snprintf(chunkBuf, sizeof(chunkBuf), "%llX", val);
+					snprintf(chunkBuf, sizeof(chunkBuf), "%I64X", val);
 
 				result.concat(chunkBuf);
 				printedAny = true;

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
@@ -309,19 +309,19 @@ public:
 
 		for (int chunk = numChunks - 1; chunk >= 0; --chunk)
 		{
-			unsigned long long val = 0;
+			unsigned __int64 val = 0;
 			for (int bit = 0; bit < 64 && (chunk * 64 + bit) < NUMBITS; ++bit)
 			{
 				if (m_bits.test(chunk * 64 + bit))
-					val |= (unsigned long long)(1) << bit;
+					val |= (unsigned __int64)(1) << bit;
 			}
 
 			if (val != 0 || chunk == 0 || printedAny)
 			{
 				if (printedAny)
-					snprintf(chunkBuf, sizeof(chunkBuf), "%016llX", val);
+					snprintf(chunkBuf, sizeof(chunkBuf), "%016I64X", val);
 				else
-					snprintf(chunkBuf, sizeof(chunkBuf), "%llX", val);
+					snprintf(chunkBuf, sizeof(chunkBuf), "%I64X", val);
 
 				result.concat(chunkBuf);
 				printedAny = true;


### PR DESCRIPTION
Logs

```log
1886: C:\VC6\VC6SP6\VC98\Bin\CL.EXE ... -c D:\a\GeneralsGameCode\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp
1887: Object.cpp
1888: ##[error]D:\a\GeneralsGameCode\GeneralsGameCode\GeneralsMD\Code\GameEngine\Include\Common/BitFlags.h(312) : error C2632: 'long' followed by 'long' is illegal
1889:         D:\a\GeneralsGameCode\GeneralsGameCode\GeneralsMD\Code\GameEngine\Include\Common/BitFlags.h(304) : while compiling class-template member function 'class AsciiString __thiscall BitFlags<512>::toHexString(void) const'

```