### PR TITLE
"Polishing" deterministic math during an actual LAN game session between native macOS GO at 30 FPS and Windows TSH

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -40,6 +40,7 @@
 #include <math.h>
 #include <float.h>
 #include <assert.h>
+#include "Lib/BaseDefines.h"
 
 #if USE_DETERMINISTIC_MATH
 #include "gmath.h"
@@ -79,7 +80,6 @@
 #define DEG_TO_RADF(x)	(((float)x)*WWMATH_PI/180.0f)
 #endif
 
-
 const int ARC_TABLE_SIZE=1024;
 const int SIN_TABLE_SIZE=1024;
 extern float _FastAcosTable[ARC_TABLE_SIZE];
@@ -105,7 +105,9 @@ static void			Shutdown();
 static WWINLINE double Pow(double x, double y);
 static WWINLINE float  Powf(float x, float y);
 static WWINLINE float  Sqrt_Legacy(float val);
-static WWINLINE double Sqrt(double x);
+static WWINLINE float  Sqrt(float x);
+	static WWINLINE float  Sqrt(int x);
+	static WWINLINE double Sqrt(double x);
 static WWINLINE float  Sqrtf(float x);
 static WWINLINE float  Inv_Sqrt_Legacy(float a);
 static WWINLINE double Inv_Sqrt(double x);
@@ -114,29 +116,39 @@ static WWINLINE float  Inv_Sqrtf(float x);
 static WWINLINE float  Fast_Acos(float val);
 static WWINLINE float  Fast_Asin(float val);
 static WWINLINE float  Acos_Legacy(float val);
-static WWINLINE double Acos(double x);
+static WWINLINE float  Acos(float x);
+	static WWINLINE double Acos(double x);
 static WWINLINE float  Acosf(float x);
 static WWINLINE float  Asin_Legacy(float val);
-static WWINLINE double Asin(double x);
+static WWINLINE float  Asin(float x);
+	static WWINLINE double Asin(double x);
 static WWINLINE float  Asinf(float x);
 static WWINLINE float  Atan_Legacy(float x);
-static WWINLINE double Atan(double x);
+static WWINLINE float  Atan(float x);
+	static WWINLINE double Atan(double x);
 static WWINLINE float  Atanf(float x);
 static WWINLINE float  Atan2_Legacy(float x, float y);
-static WWINLINE double Atan2(double x, double y);
+static WWINLINE float  Atan2(float x, float y);
+	static WWINLINE double Atan2(double x, double y);
 static WWINLINE float  Atan2f(float x, float y);
 
 static WWINLINE float  Fast_Cos(float val);
 static WWINLINE float  Fast_Inv_Cos(float val);
 static WWINLINE float  Fast_Sin(float val);
 static WWINLINE float  Fast_Inv_Sin(float val);
-static WWINLINE double Cos(double val);
+static WWINLINE float  Cos(float val);
+	static WWINLINE double Cos(double val);
 static WWINLINE float  Cosf(float val);
 static WWINLINE float  Cosf_Legacy(float val);
-static WWINLINE double Sin(double val);
+// Prevent automatic compiler promotion of float arguments to double-precision variants.
+	// Single-precision math in GameMath (gm_*f) is guaranteed to be cross-platform bit-identical,
+	// whereas double-precision math (gm_*) can diverge by 1 ULP due to FPU precision differences (x87 vs NEON).
+	static WWINLINE float  Sin(float val);
+	static WWINLINE double Sin(double val);
 static WWINLINE float  Sinf(float val);
 static WWINLINE float  Sinf_Legacy(float val);
-static WWINLINE double Tan(double x);
+static WWINLINE float  Tan(float x);
+	static WWINLINE double Tan(double x);
 static WWINLINE float  Tanf(float x);
 
 static WWINLINE double Cosh(double x);
@@ -146,7 +158,8 @@ static WWINLINE float  Sinhf(float x);
 static WWINLINE double Tanh(double x);
 static WWINLINE float  Tanhf(float x);
 
-static WWINLINE double Fabs(double x);
+static WWINLINE float  Fabs(float x);
+	static WWINLINE double Fabs(double x);
 static WWINLINE float  Fabsf(float x);
 static WWINLINE float  Fabsf_Legacy(float val);
 
@@ -203,7 +216,6 @@ static WWINLINE float Normalize_Angle(float angle); // Normalizes the angle to t
 
 };
 
-
 WWINLINE double WWMath::Pow(double x, double y)
 {
 #if USE_DETERMINISTIC_MATH
@@ -238,6 +250,24 @@ WWINLINE float WWMath::Sqrt_Legacy(float val)
 
 #else
 	return (float)sqrt((double)val);
+#endif
+}
+
+WWINLINE float WWMath::Sqrt(float x)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_sqrtf(x);
+#else
+	return (float)Sqrt((double)x);
+#endif
+}
+
+WWINLINE float WWMath::Sqrt(int x)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_sqrtf((float)x);
+#else
+	return (float)Sqrt((double)x);
 #endif
 }
 
@@ -386,6 +416,15 @@ WWINLINE float WWMath::Acos_Legacy(float val)
 #endif
 }
 
+WWINLINE float WWMath::Acos(float x)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_acosf(x);
+#else
+	return (float)Acos((double)x);
+#endif
+}
+
 WWINLINE double WWMath::Acos(double x)
 {
 #if USE_DETERMINISTIC_MATH
@@ -410,6 +449,15 @@ WWINLINE float WWMath::Asin_Legacy(float val)
 	return gm_asinf(val);
 #else
 	return (float)asin((double)val);
+#endif
+}
+
+WWINLINE float WWMath::Asin(float x)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_asinf(x);
+#else
+	return (float)Asin((double)x);
 #endif
 }
 
@@ -439,6 +487,15 @@ WWINLINE float WWMath::Atan_Legacy(float x)
 #endif
 }
 
+WWINLINE float WWMath::Atan(float x)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_atanf(x);
+#else
+	return (float)Atan((double)x);
+#endif
+}
+
 WWINLINE double WWMath::Atan(double x)
 {
 #if USE_DETERMINISTIC_MATH
@@ -463,6 +520,15 @@ WWINLINE float WWMath::Atan2_Legacy(float x, float y)
 	return gm_atan2f(x, y);
 #else
 	return (float)atan2((double)x, (double)y);
+#endif
+}
+
+WWINLINE float WWMath::Atan2(float x, float y)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_atan2f(x, y);
+#else
+	return (float)Atan2((double)x, (double)y);
 #endif
 }
 
@@ -561,6 +627,15 @@ WWINLINE float WWMath::Fast_Inv_Sin(float val)
 #endif
 }
 
+WWINLINE float WWMath::Cos(float val)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_cosf(val);
+#else
+	return (float)Cos((double)val);
+#endif
+}
+
 WWINLINE double WWMath::Cos(double val)
 {
 #if USE_DETERMINISTIC_MATH
@@ -598,6 +673,15 @@ WWINLINE float WWMath::Cosf_Legacy(float val)
 #endif
 }
 
+WWINLINE float WWMath::Sin(float val)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_sinf(val);
+#else
+	return (float)Sin((double)val);
+#endif
+}
+
 WWINLINE double WWMath::Sin(double val)
 {
 #if USE_DETERMINISTIC_MATH
@@ -632,6 +716,15 @@ WWINLINE float WWMath::Sinf_Legacy(float val)
 
 #else
 	return sinf(val);
+#endif
+}
+
+WWINLINE float WWMath::Tan(float x)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_tanf(x);
+#else
+	return (float)Tan((double)x);
 #endif
 }
 
@@ -704,6 +797,15 @@ WWINLINE float WWMath::Tanhf(float x)
 	return gm_tanhf(x);
 #else
 	return tanhf(x);
+#endif
+}
+
+WWINLINE float WWMath::Fabs(float x)
+{
+#if USE_DETERMINISTIC_MATH
+	return gm_fabsf(x);
+#else
+	return (float)Fabs((double)x);
 #endif
 }
 

--- a/Generals/Code/GameEngine/Include/Common/BitFlags.h
+++ b/Generals/Code/GameEngine/Include/Common/BitFlags.h
@@ -309,19 +309,19 @@ public:
 
 		for (int chunk = numChunks - 1; chunk >= 0; --chunk)
 		{
-			unsigned long long val = 0;
+			UnsignedInt64 val = 0;
 			for (int bit = 0; bit < 64 && (chunk * 64 + bit) < NUMBITS; ++bit)
 			{
 				if (m_bits.test(chunk * 64 + bit))
-					val |= (unsigned long long)(1) << bit;
+					val |= (UnsignedInt64)(1) << bit;
 			}
 
 			if (val != 0 || chunk == 0 || printedAny)
 			{
 				if (printedAny)
-					snprintf(chunkBuf, sizeof(chunkBuf), "%016llX", val);
+					snprintf(chunkBuf, sizeof(chunkBuf), "%016I64X", val);
 				else
-					snprintf(chunkBuf, sizeof(chunkBuf), "%llX", val);
+					snprintf(chunkBuf, sizeof(chunkBuf), "%I64X", val);
 
 				result.concat(chunkBuf);
 				printedAny = true;

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
@@ -309,19 +309,19 @@ public:
 
 		for (int chunk = numChunks - 1; chunk >= 0; --chunk)
 		{
-			unsigned long long val = 0;
+			UnsignedInt64 val = 0;
 			for (int bit = 0; bit < 64 && (chunk * 64 + bit) < NUMBITS; ++bit)
 			{
 				if (m_bits.test(chunk * 64 + bit))
-					val |= (unsigned long long)(1) << bit;
+					val |= (UnsignedInt64)(1) << bit;
 			}
 
 			if (val != 0 || chunk == 0 || printedAny)
 			{
 				if (printedAny)
-					snprintf(chunkBuf, sizeof(chunkBuf), "%016llX", val);
+					snprintf(chunkBuf, sizeof(chunkBuf), "%016I64X", val);
 				else
-					snprintf(chunkBuf, sizeof(chunkBuf), "%llX", val);
+					snprintf(chunkBuf, sizeof(chunkBuf), "%I64X", val);
 
 				result.concat(chunkBuf);
 				printedAny = true;


### PR DESCRIPTION
I performed detailed testing of a real native game, without any wrappers, Wine, or Parallels, between Mac and Windows.

Since the native Mac port is a fork of GeneralsOnlineDevelopmentTeam/GameClient, I tested Mac on this branch:
https://github.com/OKJID/GameClient/tree/okji/test/deterministic-math-v3

The branch is heavily covered with logs. And yes, I also moved the math from Xezon's branch into the GOD-team project fork, but this is unlikely to be suitable for the Windows team, because the Mac port is a complete mess. There is too much code there to even dream about merging it back into GeneralsOnlineDevelopmentTeam/GameClient...

In parallel, I tested Windows here:
https://github.com/Okladnoj/GeneralsGameCode/tree/okji/test/deterministic-math-v3

This is a fork from Xezon. This branch is heavily polluted with debug commits. The current PR is simply the cleaned-up result after testing.

Math-related desyncs have been fixed, and it is possible to play between Mac and Windows for hours even with a bad network. But there is one BUT... if you open the map from the Strategy Center, the game crashes. The problem here is not math, but different logic code.

In PartitionManager, there are two differences between GOD-team and TSH:

1. The first one is in PartitionManager.cpp:1862
 - TSH/Win: `for (Int x = 0; x <= y; ++x)` (Bresenham midpoint)
 - GOD/Mac: `for (Int x = 0; x < cellRadius; x++)` (original EA code)

2. The second one is in PartitionManager.cpp:1901-1907
 - TSH/Win: `Real cellWorldX = x * cellSize;` (without offset)
 - GOD/Mac: `getCellCenterPos(x, y, ...)` → `lo.x + x * cellSize` (with offset)

And here I do not have the authority to change anything. If only the math from TSH is moved into GOD, then everything should already work between GO players. If/when the TSH code gets into GOD, compatibility will be absolute with both GOD and TSH in any configuration.

I did not encounter any more desyncs. Of course, I did not test every game scenario: different generals, all their abilities, plus the superposition of their combinations. But I have already spent too much time on testing and debugging, so it is time to deliver the result...

Here I am attaching two replays from the Mac side and the Windows side, from their shared game, where the crash happens because the map is opened through the Strategy Center:
[temp_reps.zip](https://github.com/user-attachments/files/29152325/temp_reps.zip)