### PR TITLE
Add ObjectID heap tie-breaker in SleepyUpdates to prevent desync

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2462,7 +2462,9 @@ inline Bool isLowerPriority(const UpdateModulePtr a, const UpdateModulePtr b)
 	DEBUG_ASSERTCRASH(a && b, ("these may no longer be null"));
 	UnsignedInt f1 = a->friend_getPriority();
 	UnsignedInt f2 = b->friend_getPriority();
-	return f1 > f2;
+	if (f1 != f2)
+		return f1 > f2;
+	return a->friend_getObject()->getID() > b->friend_getObject()->getID();
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2790,7 +2790,9 @@ inline Bool isLowerPriority(const UpdateModulePtr a, const UpdateModulePtr b)
 	DEBUG_ASSERTCRASH(a && b, ("these may no longer be null"));
 	UnsignedInt f1 = a->friend_getPriority();
 	UnsignedInt f2 = b->friend_getPriority();
-	return f1 > f2;
+	if (f1 != f2)
+		return f1 > f2;
+	return a->friend_getObject()->getID() > b->friend_getObject()->getID();
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes an early-game CRC desync caused by the non-deterministic execution order of sleepy updates.

Previously in `GameLogic::isLowerPriority`, when two `UpdateModule` instances were scheduled to wake up on the exact same frame, the heap had no strict tie-breaker. This allowed identical game states to process updates in an unpredictable order across different platforms, leading to immediate RNG divergence.

By introducing a fallback comparison using the parent Object's unique ID, we guarantee a strict, deterministic ordering for the sleepy updates heap.
